### PR TITLE
Refs #9: Setting and tasks for shared virtualenvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,14 @@ set :django_settings, 'production'
 role :web, "user@127.0.0.1"
 ```
 
+Ordinarily, capistrano-django builds a separate virtualenv per-deploy.
+
+If you include:
+``` ruby
+set :shared_virtualenv, true
+```
+in your configuration file, it will instead create a virtualenv in the `shared_path`, and
+symlink it into the release path.  It will build it via requirements only when they differ
+from those of the last release.
+
 **Author:** Matthew J. Morrison.  [Follow me on Twitter](https://twitter.com/mattjmorrison)

--- a/capistrano-django.gemspec
+++ b/capistrano-django.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name     = "capistrano-django"
-  s.version  = "3.0.1"
+  s.version  = "3.1.0"
 
   s.homepage = "http://github.com/mattjmorrison/capistrano-django"
   s.summary  = %q{capistrano-django - Welcome to easy deployment with Ruby over SSH for Django}

--- a/capistrano-django.gemspec
+++ b/capistrano-django.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name     = "capistrano-django"
-  s.version  = "3.0.0"
+  s.version  = "3.0.1"
 
   s.homepage = "http://github.com/mattjmorrison/capistrano-django"
   s.summary  = %q{capistrano-django - Welcome to easy deployment with Ruby over SSH for Django}

--- a/lib/capistrano/django.rb
+++ b/lib/capistrano/django.rb
@@ -1,4 +1,4 @@
-after 'deploy:updating', 'python:create_or_update_virtualenv'
+after 'deploy:updating', 'python:create_virtualenv'
 
 namespace :deploy do
 
@@ -28,31 +28,6 @@ namespace :deploy do
 end
 
 namespace :python do
-  # Helper functions for handling shared virtualenv
-  def quiet
-    old_output = SSHKit.config.output
-    SSHKit.config.output = File.open("/dev/null", "w")
-    value = yield
-    SSHKit.config.output = old_output
-    value
-  end
-
-  def check_venv
-    puts "Checking virtualenv..."
-
-    retval = false
-
-    on roles(:all) do |h|
-      retval = if test("[ -d #{virtualenv_path} ]")
-                 installed = capture("#{virtualenv_path}/bin/pip freeze")
-                 required = capture(:cat, "#{release_path}/#{fetch(:pip_requirements)}")
-                 installed == required
-               else
-                 false
-               end
-    end
-    retval
-  end
 
   def virtualenv_path
     File.join(
@@ -60,44 +35,14 @@ namespace :python do
     )
   end
 
-  desc "Check if shared virtualenv meets requirements"
-  task :check_shared_virtualenv do
-    puts check_venv ? "Existing good virtualenv." : "Outdated or missing virtualenv."
-  end
-
-  desc "Create or update shared virtualenv if necessary"
-  task :create_or_update_virtualenv do
-    on roles(:all) do |h|
-      if fetch(:shared_virtualenv)
-        unless check_venv
-          execute "virtualenv --clear #{virtualenv_path}"
-          execute "#{virtualenv_path}/bin/pip install -r #{release_path}/#{fetch(:pip_requirements)}"
-          invoke "python:symlink_shared_virtualenv"
-          if fetch(:npm_tasks)
-            invoke 'nodejs:npm'
-          end
-          if fetch(:flask)
-            invoke 'flask:setup'
-          else
-            invoke 'django:setup'
-          end
-        end
-      else
-        invoke 'python:create_virtualenv'
-      end
-    end
-  end
-
-  desc "Symlink shared virtualenv to release"
-  task :symlink_shared_virtualenv do
-    execute :ln, "-s", virtualenv_path, File.join(release_path, 'virtualenv')
-  end
-
   desc "Create a python virtualenv"
   task :create_virtualenv do
     on roles(:all) do |h|
       execute "virtualenv #{virtualenv_path}"
       execute "#{virtualenv_path}/bin/pip install -r #{release_path}/#{fetch(:pip_requirements)}"
+      if fetch(:shared_virtualenv)
+        execute :ln, "-s", virtualenv_path, File.join(release_path, 'virtualenv')
+      end
     end
 
     if fetch(:npm_tasks)


### PR DESCRIPTION
Adds a setting, :shared_virtualenv, which causes the deployment process
to check for and create a virtualenv in the shared_path, and then
symlink it into the release_path.  This reduces deploy time in the
optimal case (requirements haven't changed) by however long it takes to
build requirements, which can be substantial.