### PR TITLE
Feature: Support for multiple celery workers

### DIFF
--- a/capistrano-django.gemspec
+++ b/capistrano-django.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name     = "capistrano-django"
-  s.version  = "3.1.0"
+  s.version  = "3.2.0"
 
   s.homepage = "http://github.com/mattjmorrison/capistrano-django"
   s.summary  = %q{capistrano-django - Welcome to easy deployment with Ruby over SSH for Django}

--- a/lib/capistrano/django.rb
+++ b/lib/capistrano/django.rb
@@ -106,6 +106,9 @@ namespace :django do
       invoke 'django:restart_celeryd'
       invoke 'django:restart_celerybeat'
     end
+    if fetch(:celery_names)
+      invoke 'django:restart_named_celery_processes'
+    end
   end
 
   desc "Restart Celeryd"
@@ -119,6 +122,18 @@ namespace :django do
   task :restart_celerybeat do
     on roles(:jobs) do
       execute "sudo service celerybeat-#{fetch(:celery_name)} restart"
+    end
+  end
+
+  desc "Restart named celery processes"
+  task :restart_named_celery_processes do
+    on roles(:jobs) do
+      fetch(:celery_names).each { | celery_name, celery_beat |
+        execute "sudo service celeryd-#{celery_name} restart"
+        if celery_beat
+          execute "sudo service celerybeat-#{celery_name} restart"
+        end
+      }
     end
   end
 


### PR DESCRIPTION
This commit provides the ability to restart multiple celeryd and
celerybeat processes for a project. Previously only one celeryd and one
celerybeat process could be restarted.

A new parameter named "celery_names" is introduced, expecting a list of
lists in this format: [ [ celery_name, has_celery_beat (true/false) ], ... ]

Example:

set :celery_names, [ [ 'queue_one', false ], [ 'queue_two', true ] ]

A deploy will restart celeryd-celery_name. If has_celery_beat is true,
it will also restart celerybeat-celery_name.