### PR TITLE
Enhancement: Updated django deploy to allow the wsgi file name to be cus...

### DIFF
--- a/capistrano-django.gemspec
+++ b/capistrano-django.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name     = "capistrano-django"
-  s.version  = "3.2.0"
+  s.version  = "3.3.0"
 
   s.homepage = "http://github.com/mattjmorrison/capistrano-django"
   s.summary  = %q{capistrano-django - Welcome to easy deployment with Ruby over SSH for Django}

--- a/lib/capistrano/django.rb
+++ b/lib/capistrano/django.rb
@@ -159,7 +159,8 @@ namespace :django do
   task :symlink_wsgi do
     on roles(:web) do
       wsgi_path = File.join(release_path, fetch(:wsgi_path, 'wsgi'))
-      execute "ln -sf #{wsgi_path}/main.wsgi #{wsgi_path}/live.wsgi"
+      wsgi_file_name = fetch(:wsgi_file_name, 'main.wsgi')
+      execute "ln -sf #{wsgi_path}/#{wsgi_file_name} #{wsgi_path}/live.wsgi"
     end
   end
 


### PR DESCRIPTION
...tomized

Django by default names the wsgi file 'wsgi.py', not 'main.wsgi' like this module expects.