### PR TITLE
Updated symlinked result to not be a variable

### DIFF
--- a/capistrano-django.gemspec
+++ b/capistrano-django.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name     = "capistrano-django"
-  s.version  = "3.3.0"
+  s.version  = "3.3.1"
 
   s.homepage = "http://github.com/mattjmorrison/capistrano-django"
   s.summary  = %q{capistrano-django - Welcome to easy deployment with Ruby over SSH for Django}

--- a/lib/capistrano/django.rb
+++ b/lib/capistrano/django.rb
@@ -160,7 +160,7 @@ namespace :django do
     on roles(:web) do
       wsgi_path = File.join(release_path, fetch(:wsgi_path, 'wsgi'))
       wsgi_file_name = fetch(:wsgi_file_name, 'main.wsgi')
-      execute "ln -sf #{wsgi_path}/#{wsgi_file_name} #{wsgi_path}/live.wsgi"
+      execute "ln -sf #{wsgi_path}/#{wsgi_file_name} wsgi/live.wsgi"
     end
   end
 


### PR DESCRIPTION
Apache config doesn't live here, and the apache config expects the production wsgi file to be at wsgi/live.wsgi